### PR TITLE
Better gtest module

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -1,43 +1,11 @@
-########################### GTEST
-# Enable ExternalProject CMake module
-INCLUDE(ExternalProject)
-
-# Set default ExternalProject root directory
-SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/third_party)
-
-# Add gtest
-# http://stackoverflow.com/questions/9689183/cmake-googletest
-ExternalProject_Add(
-    googletest
-    URL http://googletest.googlecode.com/files/gtest-1.6.0.zip
-    # TIMEOUT 10
-    # # Force separate output paths for debug and release builds to allow easy
-    # # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
-    # CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
-    #            -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
-    #            -Dgtest_force_shared_crt=ON
-    # Disable install step
-    INSTALL_COMMAND ""
-    # Wrap download, configure and build steps in a script to log output
-    LOG_DOWNLOAD ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON)
-
-# Specify include dir
-ExternalProject_Get_Property(googletest source_dir)
-set(GTEST_INCLUDE_DIR ${source_dir}/include)
-
-# Library
-ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBRARY_PATH ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
-set(GTEST_LIBRARY gtest)
-set(GTEST_MAIN_PATH ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main.a)
-set(GTEST_MAIN gtest_main)
-add_library(${GTEST_LIBRARY} UNKNOWN IMPORTED)
-add_library(${GTEST_MAIN} UNKNOWN IMPORTED)
-set_property(TARGET ${GTEST_LIBRARY} PROPERTY IMPORTED_LOCATION
-                ${GTEST_LIBRARY_PATH} )
-set_property(TARGET ${GTEST_MAIN} PROPERTY IMPORTED_LOCATION
-                ${GTEST_MAIN_PATH} )
-add_dependencies(${GTEST_LIBRARY} googletest)
-add_dependencies(${GTEST_MAIN} googletest)
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,28 @@
-include(gtest)
+# Download and unpack googletest at configure time
+configure_file(${CMAKE_MODULE_PATH}/gtest.cmake
+               googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/googletest-download )
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/googletest-download )
+
+# Add googletest directly to our build. This adds
+# the following targets: gtest, gtest_main, gmock
+# and gmock_main
+add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                 ${CMAKE_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL )
+
+# The gtest/gmock targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+include_directories("${gtest_SOURCE_DIR}/include"
+                    "${gmock_SOURCE_DIR}/include")
 
 include_directories(${GTEST_INCLUDE_DIR})
 
 set(LIBS_TO_TEST tools)
-set(TEST_LIBS gmp pthread ${LIBS_TO_TEST} ${GTEST_LIBRARY} ${GTEST_MAIN})
+set(TEST_LIBS gmp pthread ${LIBS_TO_TEST} gtest gtest_main)
 
 if (${FRACKCRYPT_TEST_UNIT})
   add_subdirectory(unit)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,3 +1,2 @@
 set(INTEGRATION_SRCS test_conversion.cc)
 add_library(integration OBJECT ${INTEGRATION_SRCS})
-add_dependencies(integration googletest)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,3 +1,2 @@
 set(UNIT_SRCS test_base64.cc test_mpz.cc)
 add_library(unit OBJECT ${UNIT_SRCS})
-add_dependencies(unit googletest)


### PR DESCRIPTION
Make googletest in the build tree
Change CMakeLists to use the googletest in the build tree
